### PR TITLE
feat(rule): add `checkImage` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ textlint --rule @textlint-rule/no-invalid-control-character README.md
 - `checkCode`: `boolean`
     - Default: `false`
     - Check code if it is `true`
+- `checkImage`: `boolean`
+    - Default: `false`
+    - Check image title and alt texts if it is `true`
 
 ```json
 {

--- a/src/textlint-rule-no-invalid-control-character.js
+++ b/src/textlint-rule-no-invalid-control-character.js
@@ -27,13 +27,16 @@ const DEFAULT_OPTION = {
     // Define allow char code like `\u0019`
     allow: [],
     // Check code if it is true
-    checkCode: false
+    checkCode: false,
+    // Check image title and alt text if it is true
+    checkImage: false
 };
 
 const reporter = (context, options = {}) => {
     const { Syntax, RuleError, getSource, fixer, report } = context;
     const allow = options.allow || DEFAULT_OPTION.allow;
     const checkCode = options.checkCode !== undefined ? options.checkCode : DEFAULT_OPTION.checkCode;
+    const checkImage = options.checkImage !== undefined ? options.checkImage : DEFAULT_OPTION.checkImage;
     const checkNode = node => {
         const text = getSource(node);
         // Ignore \r \n \t
@@ -68,6 +71,11 @@ const reporter = (context, options = {}) => {
         },
         [Syntax.Code](node) {
             if (checkCode) {
+                checkNode(node);
+            }
+        },
+        [Syntax.Image](node) {
+            if (checkImage) {
                 checkNode(node);
             }
         }

--- a/test/textlint-rule-no-invalid-control-character-test.js
+++ b/test/textlint-rule-no-invalid-control-character-test.js
@@ -39,6 +39,29 @@ tester.run("textlint-rule-no-invalid-control-character", rule, {
             options: {
                 checkCode: false
             }
+        },
+        {
+            text: `![textlint logo\u0008](https://textlint.github.io/img/textlint-icon_256x256.png "logo\u0019")`,
+            options: {
+                checkImage: false
+            }
+        },
+        {
+            text: `![textlint logo\u0008](https://textlint.github.io/img/textlint-icon_256x256.png "logo\u0019")`,
+            options: {
+                checkImage: true,
+                allow: ["\u0008", "\u0019"]
+            },
+            errors: [
+                {
+                    message: "Found invalid control character(BACKSPACE \\u0008)",
+                    index: 15
+                },
+                {
+                    message: "Found invalid control character(END OF MEDIUM \\u0019)",
+                    index: 80
+                }
+            ]
         }
     ],
     invalid: [
@@ -76,6 +99,35 @@ var value = "\u0008"
                 {
                     message: "Found invalid control character(BACKSPACE \\u0008)",
                     index: 18
+                }
+            ]
+        },
+        {
+            text: `![textlint logo\u0008](https://textlint.github.io/img/textlint-icon_256x256.png "logo\u0019")`,
+            options: {
+                checkImage: true
+            },
+            errors: [
+                {
+                    message: "Found invalid control character(BACKSPACE \\u0008)",
+                    index: 15
+                },
+                {
+                    message: "Found invalid control character(END OF MEDIUM \\u0019)",
+                    index: 80
+                }
+            ]
+        },
+        {
+            text: `![textlint logo\u0008](https://textlint.github.io/img/textlint-icon_256x256.png "logo\u0019")`,
+            options: {
+                checkImage: true,
+                allow: ["\u0019"]
+            },
+            errors: [
+                {
+                    message: "Found invalid control character(BACKSPACE \\u0008)",
+                    index: 15
                 }
             ]
         },


### PR DESCRIPTION
I had an invalid control character in image title and it led to invalid
Word document when converting with pandoc. This PR will add an option
which enables image node check.

Ref.: https://github.com/Microsoft/vscode/issues/37114