### PR TITLE
chore: checkImage: true by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ textlint --rule @textlint-rule/no-invalid-control-character README.md
     - Default: `false`
     - Check code if it is `true`
 - `checkImage`: `boolean`
-    - Default: `false`
+    - Default: `true` (v2+)
     - Check image title and alt texts if it is `true`
 
 ```json

--- a/src/textlint-rule-no-invalid-control-character.js
+++ b/src/textlint-rule-no-invalid-control-character.js
@@ -29,7 +29,7 @@ const DEFAULT_OPTION = {
     // Check code if it is true
     checkCode: false,
     // Check image title and alt text if it is true
-    checkImage: false
+    checkImage: true
 };
 
 const reporter = (context, options = {}) => {

--- a/test/textlint-rule-no-invalid-control-character-test.js
+++ b/test/textlint-rule-no-invalid-control-character-test.js
@@ -104,9 +104,6 @@ var value = "\u0008"
         },
         {
             text: `![textlint logo\u0008](https://textlint.github.io/img/textlint-icon_256x256.png "logo\u0019")`,
-            options: {
-                checkImage: true
-            },
             errors: [
                 {
                     message: "Found invalid control character(BACKSPACE \\u0008)",


### PR DESCRIPTION
BREAKING CHANGE: `checkImage` option is enabled by default

fix #2 