### PR TITLE
add some characters including bidi formatting characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "src/"
   ],
   "name": "@textlint-rule/textlint-rule-no-invalid-control-character",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "description": "textlint rule check unnessary control character in the document.",
   "main": "lib/textlint-rule-no-invalid-control-character.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "src/"
   ],
   "name": "@textlint-rule/textlint-rule-no-invalid-control-character",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "textlint rule check unnessary control character in the document.",
   "main": "lib/textlint-rule-no-invalid-control-character.js",
   "scripts": {

--- a/src/CONTROL_CHARACTERS.js
+++ b/src/CONTROL_CHARACTERS.js
@@ -104,6 +104,170 @@ const CONTROL_CHARACTERS = [
     {
         code: "\u001A",
         name: "SUBSTITUTE"
+    },
+    {
+        code: "\u001B",
+        name: "ESCAPE"
+    },
+    {
+        code: "\u001C",
+        name: "INFORMATION SEPARATOR FOUR"
+    },
+    {
+        code: "\u001D",
+        name: "INFORMATION SEPARATOR THREE"
+    },
+    {
+        code: "\u001E",
+        name: "INFORMATION SEPARATOR TWO"
+    },
+    {
+        code: "\u001F",
+        name: "INFORMATION SEPARATOR ONE"
+    },
+    {
+        code: "\u007F",
+        name: "DELETE"
+    },
+    {
+        code: "\u0080",
+        name: "PADDING CHARACTER"
+    },
+    {
+        code: "\u0081",
+        name: "HIGH OCTET PRESET"
+    },
+    {
+        code: "\u0082",
+        name: "BREAK PERMITTED HERE"
+    },
+    {
+        code: "\u0083",
+        name: "NO BREAK HERE"
+    },
+    {
+        code: "\u0084",
+        name: "INDEX"
+    },
+    {
+        code: "\u0085",
+        name: "NEXT LINE (NEL)"
+    },
+    {
+        code: "\u0086",
+        name: "START OF SELECTED AREA"
+    },
+    {
+        code: "\u0087",
+        name: "END OF SELECTED AREA"
+    },
+    {
+        code: "\u0088",
+        name: "CHARACTER TABULATION SET"
+    },
+    {
+        code: "\u0089",
+        name: "CHARACTER TABULATION WITH JUSTIFICATION"
+    },
+    {
+        code: "\u008A",
+        name: "LINE TABULATION SET"
+    },
+    {
+        code: "\u008B",
+        name: "PARTIAL LINE FORWARD"
+    },
+    {
+        code: "\u008C",
+        name: "PARTIAL LINE BACKWARD"
+    },
+    {
+        code: "\u008D",
+        name: "REVERSE LINE FEED"
+    },
+    {
+        code: "\u008E",
+        name: "SINGLE SHIFT TWO"
+    },
+    {
+        code: "\u008F",
+        name: "SINGLE SHIFT THREE"
+    },
+    {
+        code: "\u0090",
+        name: "DEVICE CONTROL STRING"
+    },
+    {
+        code: "\u0091",
+        name: "PRIVATE USE ONE"
+    },
+    {
+        code: "\u0092",
+        name: "PRIVATE USE TWO"
+    },
+    {
+        code: "\u0093",
+        name: "SET TRANSMIT STATE"
+    },
+    {
+        code: "\u0094",
+        name: "CANCEL CHARACTER"
+    },
+    {
+        code: "\u0095",
+        name: "MESSAGE WAITING"
+    },
+    {
+        code: "\u0096",
+        name: "START OF GUARDED AREA"
+    },
+    {
+        code: "\u0097",
+        name: "END OF GUARDED AREA"
+    },
+    {
+        code: "\u0098",
+        name: "START OF STRING"
+    },
+    {
+        code: "\u0099",
+        name: "SINGLE GRAPHIC CHARACTER INTRODUCER"
+    },
+    {
+        code: "\u009A",
+        name: "SINGLE CHARACTER INTRODUCER"
+    },
+    {
+        code: "\u009B",
+        name: "CONTROL SEQUENCE INTRODUCER"
+    },
+    {
+        code: "\u009C",
+        name: "STRING TERMINATOR"
+    },
+    {
+        code: "\u009D",
+        name: "OPERATING SYSTEM COMMAND"
+    },
+    {
+        code: "\u009E",
+        name: "PRIVACY MESSAGE"
+    },
+    {
+        code: "\u009F",
+        name: "APPLICATION PROGRAM COMMAND"
+    },
+    {
+        code: "\u202C",
+        name: "POP DIRECTIONAL FORMATTING"
+    },
+    {
+        code: "\u202D",
+        name: "LEFT-TO-RIGHT OVERRIDE"
+    },
+    {
+        code: "\u202E",
+        name: "RIGHT-TO-LEFT OVERRIDE"
     }
 ];
 

--- a/src/textlint-rule-no-invalid-control-character.js
+++ b/src/textlint-rule-no-invalid-control-character.js
@@ -40,7 +40,14 @@ const reporter = (context, options = {}) => {
     const checkNode = (node) => {
         const text = getSource(node);
         // Ignore \r \n \t
-        const controlCharacterPattern = /([\x00-\x08\x0B\x0C\x0E-\x1F\x7F])/g;
+        const asciiControlCharacters = "\x00-\x08\x0B\x0C\x0E-\x1F\x7F";
+        const c1ControlCharacters = "\x80-\x89\x8A-\x9F";
+        const bidiFormattingCharacters = "\u202A-\u202E";
+        const controlCharacterPattern = new RegExp(
+            `([${asciiControlCharacters}${c1ControlCharacters}${bidiFormattingCharacters}])`,
+            "g"
+        );
+
         /**
          * @type {Array<{match:string, sub:string[], index:number}>}
          */


### PR DESCRIPTION
I created constants for the clarity of regex

About the bidirectional formatting characters:
they're not usually considered control characters, but they appear when the text is copied from binary formats like PDF. I don't think they should appear in text and that the formatting to be done during rendering, not in the text itself.